### PR TITLE
Adds fallback for 1.25 clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ To monitor additional hosts, simply relate the Dockerbeat subordinate
 
     juju add-relation dockerbeat:beats-host my-charm
 
+## DockerBeat Delivery
+
+This charm makes use of Resources. A juju 2.0 feature. When deploying this
+charm on a juju 2.0 enabled controller, the upstream ingensi dockerbeat
+binary will ship with the charm targeted at X86 hosts. If you are on another
+architecture you may need to compile, and `juju attach` a new binary for
+your arch.
+
+### 1.25 Compatibility
+Alternatively, on juju 1.25 hosts, this charm supports a configurable URL and
+SHA1 sum configuration option to attempt to fetch. Configured for a release
+from the ingensi github repository.
 
 ## Contact information
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ To monitor additional hosts, simply relate the Dockerbeat subordinate
 ## DockerBeat Delivery
 
 This charm makes use of Resources. A juju 2.0 feature. When deploying this
-charm on a juju 2.0 enabled controller, the upstream ingensi dockerbeat
+charm on a juju 2.0 enabled controller, the upstream Ingensi dockerbeat
 binary will ship with the charm targeted at X86 hosts. If you are on another
 architecture you may need to compile, and `juju attach` a new binary for
 your arch.
@@ -90,7 +90,7 @@ your arch.
 ### 1.25 Compatibility
 Alternatively, on juju 1.25 hosts, this charm supports a configurable URL and
 SHA1 sum configuration option to attempt to fetch. Configured for a release
-from the ingensi github repository.
+from the Ingensi github repository.
 
 ## Contact information
 
@@ -98,6 +98,6 @@ from the ingensi github repository.
 
 # Need Help?
 
-- [DockerBeat Upstream](https://github.com/ingensi/dockerbeat)
+- [DockerBeat Upstream](https://github.com/Ingensi/dockerbeat)
 - [Juju mailing list](https://lists.ubuntu.com/mailman/listinfo/juju)
 - [Juju Community](https://jujucharms.com/community)

--- a/config.yaml
+++ b/config.yaml
@@ -21,3 +21,11 @@ options:
   docker_key_path:
     type: string
     default: /etc/docker/key.pem
+  fallback_url:
+    type: string
+    default: https://github.com/Ingensi/dockerbeat/releases/download/v1.0.0-rc1/dockerbeat-1.0.0-rc1-x86_64
+    description: URL to download dockerbeat binary release
+  fallback_sum:
+    type: string
+    default: c68767814e7f3bf256da52b28281a44bf392fecd
+    description: SHA1 sum of fallback_url payload

--- a/reactive/dockerbeat.py
+++ b/reactive/dockerbeat.py
@@ -52,6 +52,11 @@ def install_dockerbeat():
     set_state('dockerbeat.installed')
 
 
+@when_any('config.fallback_url.changed', 'config.fallback_sum.changed')
+def remove_ready_state():
+    remove_state('dockerbeat.installed')
+
+
 @when('beat.render')
 @when_any('elasticsearch.available', 'logstash.available')
 def render_beat_template():

--- a/reactive/dockerbeat.py
+++ b/reactive/dockerbeat.py
@@ -4,11 +4,13 @@ from charms.reactive import when_not
 from charms.reactive import set_state
 from charms.reactive import remove_state
 
+from charmhelpers.core.hookenv import config
 from charmhelpers.core.hookenv import resource_get
 from charmhelpers.core.hookenv import status_set
 from charmhelpers.core.host import lsb_release
 from charmhelpers.core.host import service_restart
 from charmhelpers.core.templating import render
+from charmhelpers.fetch.archiveurl import ArchiveUrlFetchHandler
 
 from elasticbeats import render_without_context
 from elasticbeats import push_beat_index
@@ -21,12 +23,19 @@ import os
 
 @when_not('dockerbeat.installed')
 def install_dockerbeat():
-    ''' Installs dockerbeat from resources. '''
-    bin_path = resource_get('dockerbeat')
+    ''' Installs dockerbeat from resources, with a fallback option
+    to try to fetch over the network, for 1.25.5 hosts'''
+
+    try:
+        bin_path = resource_get('dockerbeat')
+    except NotImplementedError:
+        # Attempt to fetch and install from configured uri with validation
+        bin_path = download_from_upstream()
+
     full_beat_path = '/usr/local/bin/dockerbeat'
 
     if not bin_path:
-        status_set('blocked', 'Please provide the dockerbeat binary')
+        status_set('blocked', 'Missing dockerbeat binary')
         return
 
     install(bin_path, full_beat_path)
@@ -67,6 +76,15 @@ def push_dockerbeat_index(elasticsearch):
         host_string = "{}:{}".format(host['host'], host['port'])
     push_beat_index(host_string, 'dockerbeat')
     set_state('dockerbeat.index.pushed')
+
+
+def download_from_upstream():
+    if not config('fallback_url') or not config('fallback_sum'):
+        status_set('blocked', 'Missing configuration: ')
+        return None
+    client = ArchiveUrlFetchHandler()
+    return client.download_and_validate(config('fallback_url'),
+                                        config('fallback_sum'))
 
 
 def install(src, tgt):


### PR DESCRIPTION
This adds a fetch from configured url option to fetch a dockerbeat release. Defaults to the current upstream release candidate.

Must contain a matching SHA1 sum, otherwise the download will fail and the charm will be in a blocked state.
